### PR TITLE
removed _EUR suffix from income, as per #18

### DIFF
--- a/analysis/src/main/java/de/tum/bgu/msm/ModeChoiceCalculatorWithPriceFactors.java
+++ b/analysis/src/main/java/de/tum/bgu/msm/ModeChoiceCalculatorWithPriceFactors.java
@@ -31,16 +31,16 @@ public class ModeChoiceCalculatorWithPriceFactors extends ModeChoiceCalculator20
         double gcTramMetro = generalizedCosts.get(Mode.tramOrMetro);
         double gcTaxi = generalizedCosts.get(Mode.taxi);
 
-        int monthlyIncome_EUR = household.getMonthlyIncome_EUR();
+        int monthlyIncome = household.getMonthlyIncome();
 
-        if (monthlyIncome_EUR <= 1500) {
+        if (monthlyIncome <= 1500) {
             gcAutoD += travelDistanceAuto * coef.get(Mode.autoDriver).get("costPerKm") * (carPriceFactor - 1) / coef.get(Mode.autoDriver).get("vot_under_1500_eur_min");
             gcAutoP += travelDistanceAuto * coef.get(Mode.autoPassenger).get("costPerKm") * (carPriceFactor - 1) /coef.get(Mode.autoPassenger).get("vot_under_1500_eur_min");
             gcBus += travelDistanceAuto * coef.get(Mode.bus).get("costPerKm") * (ptPriceFactor - 1) / coef.get(Mode.bus).get("vot_under_1500_eur_min");
             gcTrain += travelDistanceAuto * coef.get(Mode.train).get("costPerKm") * (ptPriceFactor - 1) / coef.get(Mode.train).get("vot_under_1500_eur_min");
             gcTramMetro += travelDistanceAuto * coef.get(Mode.tramOrMetro).get("costPerKm") * (ptPriceFactor - 1) / coef.get(Mode.tramOrMetro).get("vot_under_1500_eur_min");
             gcTaxi += travelDistanceAuto * coef.get(Mode.taxi).get("costPerKm") * (ptPriceFactor - 1) / coef.get(Mode.taxi).get("vot_under_1500_eur_min");
-        } else if (monthlyIncome_EUR <= 5600) {
+        } else if (monthlyIncome <= 5600) {
             gcAutoD += travelDistanceAuto * coef.get(Mode.autoDriver).get("costPerKm") * (carPriceFactor - 1) /coef.get(Mode.autoDriver).get("vot_1500_to_5600_eur_min");
             gcAutoP += travelDistanceAuto * coef.get(Mode.autoPassenger).get("costPerKm") * (carPriceFactor - 1) / coef.get(Mode.autoPassenger).get("vot_1500_to_5600_eur_min");
             gcBus += travelDistanceAuto * coef.get(Mode.bus).get("costPerKm") * (ptPriceFactor - 1) / coef.get(Mode.bus).get("vot_1500_to_5600_eur_min");

--- a/extensions/mito7days/src/main/java/de/tum/bgu/msm/io/PersonsReader7days.java
+++ b/extensions/mito7days/src/main/java/de/tum/bgu/msm/io/PersonsReader7days.java
@@ -38,7 +38,7 @@ public class PersonsReader7days extends AbstractCsvReader {
         super.read(filePath, ",");
         int noIncomeHouseholds = 0;
         for(MitoHousehold household: dataSet.getHouseholds().values()) {
-            if(household.getMonthlyIncome_EUR() == 0) {
+            if(household.getMonthlyIncome() == 0) {
                 noIncomeHouseholds++;
             }
         }
@@ -89,8 +89,8 @@ public class PersonsReader7days extends AbstractCsvReader {
 
 
         //mito uses monthly income, while SILO uses annual income
-        int monthlyIncome_EUR = Integer.parseInt(record[posIncome])/12;
-        hh.addIncome(monthlyIncome_EUR);
+        int monthlyIncome = Integer.parseInt(record[posIncome])/12;
+        hh.addIncome(monthlyIncome);
 
         MitoOccupation occupation = null;
 

--- a/mitoCore/src/main/java/de/tum/bgu/msm/data/MitoHousehold.java
+++ b/mitoCore/src/main/java/de/tum/bgu/msm/data/MitoHousehold.java
@@ -18,7 +18,7 @@ public class MitoHousehold implements Id, MicroLocation {
     private static final Logger logger = LogManager.getLogger(MitoHousehold.class);
 
     private final int hhId;
-    private int monthlyIncome_EUR;
+    private int monthlyIncome;
     private int economicStatus;
     private final int autos;
     private final boolean modelled;
@@ -29,9 +29,9 @@ public class MitoHousehold implements Id, MicroLocation {
 
     private final Map<Integer, MitoPerson> persons  = new HashMap<>();
 
-    public MitoHousehold(int id, int monthlyIncome_EUR, int autos, boolean modelled) {
+    public MitoHousehold(int id, int monthlyIncome, int autos, boolean modelled) {
         this.hhId = id;
-        this.monthlyIncome_EUR = monthlyIncome_EUR;
+        this.monthlyIncome = monthlyIncome;
         this.autos = autos;
         this.modelled = modelled;
     }
@@ -45,12 +45,12 @@ public class MitoHousehold implements Id, MicroLocation {
         return persons.size();
     }
 
-    public int getMonthlyIncome_EUR() {
-        return monthlyIncome_EUR;
+    public int getMonthlyIncome() {
+        return monthlyIncome;
     }
 
     public void addIncome(int inc) {
-        monthlyIncome_EUR += inc;
+        monthlyIncome += inc;
     }
 
     public int getAutos() {

--- a/mitoCore/src/main/java/de/tum/bgu/msm/io/input/readers/EconomicStatusReader.java
+++ b/mitoCore/src/main/java/de/tum/bgu/msm/io/input/readers/EconomicStatusReader.java
@@ -120,7 +120,7 @@ public class EconomicStatusReader extends AbstractCsvReader {
         // im Haushalt wurde eine Person mit dem Faktor 1, alle weiteren Personen ab 15
         // Jahren mit dem Faktor 0,5 gewichtet.
         float weightedHhSize = MitoUtil.rounder(Math.min(3.5f, 1.0f + (countAdults - 1f) * 0.5f + countChildren * 0.3f), 1);
-        String incomeCategory = getMidIncomeCategory(hh.getMonthlyIncome_EUR());
+        String incomeCategory = getMidIncomeCategory(hh.getMonthlyIncome());
         return economicStatusDefinition.get(weightedHhSize+"_"+incomeCategory);
     }
 

--- a/mitoCore/src/main/java/de/tum/bgu/msm/io/input/readers/PersonsReader.java
+++ b/mitoCore/src/main/java/de/tum/bgu/msm/io/input/readers/PersonsReader.java
@@ -38,7 +38,7 @@ public class PersonsReader extends AbstractCsvReader {
         super.read(filePath, ",");
         int noIncomeHouseholds = 0;
         for(MitoHousehold household: dataSet.getHouseholds().values()) {
-            if(household.getMonthlyIncome_EUR() == 0) {
+            if(household.getMonthlyIncome() == 0) {
                 noIncomeHouseholds++;
             }
         }
@@ -89,8 +89,8 @@ public class PersonsReader extends AbstractCsvReader {
 
 
         //mito uses monthly income, while SILO uses annual income
-        int monthlyIncome_EUR = Integer.parseInt(record[posIncome])/12;
-        hh.addIncome(monthlyIncome_EUR);
+        int monthlyIncome = Integer.parseInt(record[posIncome])/12;
+        hh.addIncome(monthlyIncome);
 
         MitoOccupation occupation = null;
 

--- a/mitoCore/src/main/java/de/tum/bgu/msm/io/input/readers/SyntheticPopulationReaderGermany.java
+++ b/mitoCore/src/main/java/de/tum/bgu/msm/io/input/readers/SyntheticPopulationReaderGermany.java
@@ -53,7 +53,7 @@ public class SyntheticPopulationReaderGermany extends AbstractCsvReader {
         super.read(filePath, ",");
         int noIncomeHouseholds = 0;
         for(MitoHousehold household: dataSet.getHouseholds().values()) {
-            if(household.getMonthlyIncome_EUR() == 0) {
+            if(household.getMonthlyIncome() == 0) {
                 noIncomeHouseholds++;
             }
         }

--- a/mitoCore/src/main/resources/de.tum.bgu.msm/modules/modeChoice/ModeChoiceShortDistance
+++ b/mitoCore/src/main/resources/de.tum.bgu.msm/modules/modeChoice/ModeChoiceShortDistance
@@ -59,7 +59,7 @@ var calculateHBWProbabilities = function (hh, person, originZone, destinationZon
     timeTrain = travelTimes.getTravelTime(originZone, destinationZone, peakHour, "train");
     timeTramMetro = travelTimes.getTravelTime(originZone, destinationZone, peakHour, "tramMetro");
 
-    monthlyIncome_EUR = hh.getMonthlyIncome_EUR();
+    monthlyIncome = hh.getmonthlyIncome();
     age = person.getAge();
     gender = person.getMitoGender();
     driversLicense = person.hasDriversLicense();
@@ -70,21 +70,21 @@ var calculateHBWProbabilities = function (hh, person, originZone, destinationZon
     isMunichTrip = originZone.isMunichZone();
 
 
-    if (monthlyIncome_EUR <= 1500) {
+    if (monthlyIncome <= 1500) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT1500_HBW_HBE_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT1500_HBW_HBE_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_HBW_HBE_transit;
         gcTrain = timeTrain + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_HBW_HBE_transit;
         gcTramMetro = timeTramMetro + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_HBW_HBE_transit;
         gcTNC = timeAutoD + (travelDistanceAuto * TNCCostEurosPerKm) / VOT1500_HBW_HBE_TNC; // change in VOT and cost
-    } else if (monthlyIncome_EUR > 1500 && monthlyIncome_EUR <= 5600) {
+    } else if (monthlyIncome > 1500 && monthlyIncome <= 5600) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT5600_HBW_HBE_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT5600_HBW_HBE_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_HBW_HBE_transit;
         gcTrain = timeTrain + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_HBW_HBE_transit;
         gcTramMetro = timeTramMetro + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_HBW_HBE_transit;
         gcSTNC = timeAutoD + (travelDistanceAuto * TNCCostEurosPerKm) / VOT5600_HBW_HBE_TNC; // change in VOT and cost
-    } else if (monthlyIncome_EUR > 5600) {
+    } else if (monthlyIncome > 5600) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT7000_HBW_HBE_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT7000_HBW_HBE_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT7000_HBW_HBE_transit;
@@ -201,28 +201,28 @@ var calculateHBEProbabilities = function (hh, person, originZone, destinationZon
     timeTrain = travelTimes.getTravelTime(originZone, destinationZone, peakHour, "train");
     timeTramMetro = travelTimes.getTravelTime(originZone, destinationZone, peakHour, "tramMetro");
 
-    monthlyIncome_EUR = hh.getMonthlyIncome_EUR();
+    monthlyIncome = hh.getmonthlyIncome();
     gender = person.getMitoGender();
     driversLicense = person.hasDriversLicense();
     hhAutos = hh.getAutos();
     distToRailStop = originZone.getDistanceToNearestRailStop();
     isMunichTrip = originZone.isMunichZone();
 
-    if (monthlyIncome_EUR <= 1500) {
+    if (monthlyIncome <= 1500) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT1500_HBW_HBE_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT1500_HBW_HBE_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_HBW_HBE_transit;
         gcTrain = timeTrain + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_HBW_HBE_transit;
         gcTramMetro = timeTramMetro + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_HBW_HBE_transit;
         gcTNC = timeAutoD + (travelDistanceAuto * TNCCostEurosPerKm) / VOT1500_HBW_HBE_TNC; // change in VOT and cost
-    } else if (monthlyIncome_EUR > 1500 && monthlyIncome_EUR <= 5600) {
+    } else if (monthlyIncome > 1500 && monthlyIncome <= 5600) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT5600_HBW_HBE_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT5600_HBW_HBE_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_HBW_HBE_transit;
         gcTrain = timeTrain + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_HBW_HBE_transit;
         gcTramMetro = timeTramMetro + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_HBW_HBE_transit;
         gcTNC = timeAutoD + (travelDistanceAuto * TNCCostEurosPerKm) / VOT5600_HBW_HBE_TNC; // change in VOT and cost
-    } else if (monthlyIncome_EUR > 5600) {
+    } else if (monthlyIncome > 5600) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT7000_HBW_HBE_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT7000_HBW_HBE_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT7000_HBW_HBE_transit;
@@ -324,28 +324,28 @@ var calculateHBSProbabilities = function (hh, person, originZone, destinationZon
     timeTrain = travelTimes.getTravelTime(originZone, destinationZone, peakHour, "train");
     timeTramMetro = travelTimes.getTravelTime(originZone, destinationZone, peakHour, "tramMetro");
 
-    monthlyIncome_EUR = hh.getMonthlyIncome_EUR();
+    monthlyIncome = hh.getmonthlyIncome();
     gender = person.getMitoGender();
     driversLicense = person.hasDriversLicense();
     hhAutos = hh.getAutos();
     distToRailStop = originZone.getDistanceToNearestRailStop();
     isMunichTrip = originZone.isMunichZone();
 
-    if (monthlyIncome_EUR <= 1500) {
+    if (monthlyIncome <= 1500) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT1500_other_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT1500_other_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_other_transit;
         gcTrain = timeTrain + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_other_transit;
         gcTramMetro = timeTramMetro + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_other_transit;
         gcTNC = timeAutoD + (travelDistanceAuto * TNCCostEurosPerKm) / VOT1500_other_TNC; // change in VOT and cost
-    } else if (monthlyIncome_EUR > 1500 && monthlyIncome_EUR <= 5600) {
+    } else if (monthlyIncome > 1500 && monthlyIncome <= 5600) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT5600_other_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT5600_other_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_other_transit;
         gcTrain = timeTrain + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_other_transit;
         gcTramMetro = timeTramMetro + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_other_transit;
         gcTNC = timeAutoD + (travelDistanceAuto * TNCCostEurosPerKm) / VOT5600_other_TNC; // change in VOT and cost
-    } else if (monthlyIncome_EUR > 5600) {
+    } else if (monthlyIncome > 5600) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT7000_other_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT7000_other_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT7000_other_transit;
@@ -442,7 +442,7 @@ var calculateHBOProbabilities = function (hh, person, originZone, destinationZon
     timeTrain = travelTimes.getTravelTime(originZone, destinationZone, peakHour, "train");
     timeTramMetro = travelTimes.getTravelTime(originZone, destinationZone, peakHour, "tramMetro");
 
-    monthlyIncome_EUR = hh.getMonthlyIncome_EUR();
+    monthlyIncome = hh.getmonthlyIncome();
     gender = person.getMitoGender();
     driversLicense = person.hasDriversLicense();
     hhAutos = hh.getAutos();
@@ -450,21 +450,21 @@ var calculateHBOProbabilities = function (hh, person, originZone, destinationZon
     distToRailStop = originZone.getDistanceToNearestRailStop();
     isMunichTrip = originZone.isMunichZone();
 
-    if (monthlyIncome_EUR <= 1500) {
+    if (monthlyIncome <= 1500) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT1500_other_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT1500_other_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_other_transit;
         gcTrain = timeTrain + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_other_transit;
         gcTramMetro = timeTramMetro + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_other_transit;
         gcTNC = timeAutoD + (travelDistanceAuto * TNCCostEurosPerKm) / VOT1500_other_TNC; // change in VOT and cost
-    } else if (monthlyIncome_EUR > 1500 && monthlyIncome_EUR <= 5600) {
+    } else if (monthlyIncome > 1500 && monthlyIncome <= 5600) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT5600_other_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT5600_other_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_other_transit;
         gcTrain = timeTrain + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_other_transit;
         gcTramMetro = timeTramMetro + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_other_transit;
         gcTNC = timeAutoD + (travelDistanceAuto * TNCCostEurosPerKm) / VOT5600_other_TNC; // change in VOT and cost
-    } else if (monthlyIncome_EUR > 5600) {
+    } else if (monthlyIncome > 5600) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT7000_other_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT7000_other_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT7000_other_transit;
@@ -559,27 +559,27 @@ var calculateNHBWProbabilities = function (hh, person, originZone, destinationZo
     timeTrain = travelTimes.getTravelTime(originZone, destinationZone, peakHour, "train");
     timeTramMetro = travelTimes.getTravelTime(originZone, destinationZone, peakHour, "tramMetro");
 
-    monthlyIncome_EUR = hh.getMonthlyIncome_EUR();
+    monthlyIncome = hh.getmonthlyIncome();
     age = person.getAge();
     driversLicense = person.hasDriversLicense();
     hhAutos = hh.getAutos();
     distToRailStop = originZone.getDistanceToNearestRailStop();
 
-    if (monthlyIncome_EUR <= 1500) {
+    if (monthlyIncome <= 1500) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT1500_other_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT1500_other_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_other_transit;
         gcTrain = timeTrain + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_other_transit;
         gcTramMetro = timeTramMetro + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_other_transit;
         gcTNC = timeAutoD + (travelDistanceAuto * TNCCostEurosPerKm) / VOT1500_other_TNC; // change in VOT and cost
-    } else if (monthlyIncome_EUR > 1500 && monthlyIncome_EUR <= 5600) {
+    } else if (monthlyIncome > 1500 && monthlyIncome <= 5600) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT5600_other_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT5600_other_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_other_transit;
         gcTrain = timeTrain + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_other_transit;
         gcTramMetro = timeTramMetro + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_other_transit;
         gcTNC = timeAutoD + (travelDistanceAuto * TNCCostEurosPerKm) / VOT5600_other_TNC; // change in VOT and cost
-    } else if (monthlyIncome_EUR > 5600) {
+    } else if (monthlyIncome > 5600) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT7000_other_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT7000_other_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT7000_other_transit;
@@ -670,28 +670,28 @@ var calculateNHBOProbabilities = function (hh, person, originZone, destinationZo
     timeTrain = travelTimes.getTravelTime(originZone, destinationZone, peakHour, "train");
     timeTramMetro = travelTimes.getTravelTime(originZone, destinationZone, peakHour, "tramMetro");
 
-    monthlyIncome_EUR = hh.getMonthlyIncome_EUR();
+    monthlyIncome = hh.getmonthlyIncome();
     gender = person.getMitoGender();
     driversLicense = person.hasDriversLicense();
     hhAutos = hh.getAutos();
     distToRailStop = originZone.getDistanceToNearestRailStop();
     areaType = originZone.getAreaTypeR();
 
-    if (monthlyIncome_EUR <= 1500) {
+    if (monthlyIncome <= 1500) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT1500_other_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT1500_other_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_other_transit;
         gcTrain = timeTrain + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_other_transit;
         gcTramMetro = timeTramMetro + (travelDistanceAuto * transitFareEurosPerKm) / VOT1500_other_transit;
         gcTNC = timeAutoD + (travelDistanceAuto * TNCCostEurosPerKm) / VOT1500_other_TNC; // change in VOT and cost
-    } else if (monthlyIncome_EUR > 1500 && monthlyIncome_EUR <= 5600) {
+    } else if (monthlyIncome > 1500 && monthlyIncome <= 5600) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT5600_other_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT5600_other_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_other_transit;
         gcTrain = timeTrain + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_other_transit;
         gcTramMetro = timeTramMetro + (travelDistanceAuto * transitFareEurosPerKm) / VOT5600_other_transit;
         gcTNC = timeAutoD + (travelDistanceAuto * TNCCostEurosPerKm) / VOT5600_other_TNC; // change in VOT and cost
-    } else if (monthlyIncome_EUR > 5600) {
+    } else if (monthlyIncome > 5600) {
         gcAutoD = timeAutoD + (travelDistanceAuto * fuelCostEurosPerKm) / VOT7000_other_autoD;
         gcAutoP = timeAutoP + (travelDistanceAuto * fuelCostEurosPerKm) / VOT7000_other_autoP;
         gcBus = timeBus + (travelDistanceAuto * transitFareEurosPerKm) / VOT7000_other_transit;

--- a/useCases/germany/src/main/java/de/tum/bgu/msm/modules/ModeChoiceCalculator2017Impl.java
+++ b/useCases/germany/src/main/java/de/tum/bgu/msm/modules/ModeChoiceCalculator2017Impl.java
@@ -177,7 +177,7 @@ public class ModeChoiceCalculator2017Impl extends AbstractModeChoiceCalculator {
         double timeTramMetro = travelTimes.getTravelTime(originZone, destinationZone, peakHour_s, "tramMetro");
         double timeTaxi = timeAutoD;
 
-        int monthlyIncome_EUR = household.getMonthlyIncome_EUR();
+        int monthlyIncome_EUR = household.getMonthlyIncome();
 
         double gcAutoD;
         double gcAutoP;

--- a/useCases/manchester/src/main/java/uk/cam/mrc/phm/calculators/ModeChoiceCalculatorMCR.java
+++ b/useCases/manchester/src/main/java/uk/cam/mrc/phm/calculators/ModeChoiceCalculatorMCR.java
@@ -38,7 +38,7 @@ public class ModeChoiceCalculatorMCR extends AbstractModeChoiceCalculator {
     public EnumMap<Mode, Double> calculateUtilities(Purpose purpose, MitoHousehold household, MitoPerson person, MitoZone originZone, MitoZone destinationZone, TravelTimes travelTimes, double travelDistanceAuto, double travelDistanceNMT, double peakHour_s) {
         int age = person.getAge();
         boolean male = person.getMitoGender().equals(MitoGender.MALE);
-        int hhincome = household.getMonthlyIncome_EUR();
+        int hhincome = household.getMonthlyIncome();
         int hhAutos = household.getAutos();
 
         EnumMap<Mode, Double> generalizedCosts = calculateGeneralizedCosts(purpose, household, person,

--- a/useCases/melbourne/src/main/java/uk/cam/mrc/phm/calculators/ModeChoiceCalculatorMEL.java
+++ b/useCases/melbourne/src/main/java/uk/cam/mrc/phm/calculators/ModeChoiceCalculatorMEL.java
@@ -27,7 +27,7 @@ public class ModeChoiceCalculatorMEL extends AbstractModeChoiceCalculator {
 
     private void setNests() {
         List<Tuple<EnumSet<Mode>, Double>> nests = new ArrayList<>();
-        //TODO: currently the manchester mode choice model is MNL, no nests
+        //TODO: currently the melbourne mode choice model is MNL, no nests
         nests = null;
 //        nests.add(new Tuple<>(EnumSet.of(autoDriver,autoPassenger), 0.25));
 //        nests.add(new Tuple<>(EnumSet.of(train, tramOrMetro, bus, taxi), 0.25));
@@ -38,7 +38,7 @@ public class ModeChoiceCalculatorMEL extends AbstractModeChoiceCalculator {
     public EnumMap<Mode, Double> calculateUtilities(Purpose purpose, MitoHousehold household, MitoPerson person, MitoZone originZone, MitoZone destinationZone, TravelTimes travelTimes, double travelDistanceAuto, double travelDistanceNMT, double peakHour_s) {
         int age = person.getAge();
         boolean male = person.getMitoGender().equals(MitoGender.MALE);
-        int hhincome = household.getMonthlyIncome_EUR();
+        int hhincome = household.getMonthlyIncome();
         int hhAutos = household.getAutos();
 
         EnumMap<Mode, Double> generalizedCosts = calculateGeneralizedCosts(purpose, household, person,

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/modules/ModeChoiceCalculator2008Impl.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/modules/ModeChoiceCalculator2008Impl.java
@@ -99,7 +99,7 @@ public class ModeChoiceCalculator2008Impl extends AbstractModeChoiceCalculator {
         double timeTrain = travelTimes.getTravelTime(originZone, destinationZone, peakHour_s, "train");
         double timeTramMetro = travelTimes.getTravelTime(originZone, destinationZone, peakHour_s, "tramMetro");
 
-        int monthlyIncome_EUR = household.getMonthlyIncome_EUR();
+        int monthlyIncome_EUR = household.getMonthlyIncome();
 
         double gcAutoD;
         double gcAutoP;

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/modules/ModeChoiceCalculator2017Impl.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/modules/ModeChoiceCalculator2017Impl.java
@@ -178,7 +178,7 @@ public class ModeChoiceCalculator2017Impl extends AbstractModeChoiceCalculator {
         double timeTramMetro = travelTimes.getTravelTime(originZone, destinationZone, peakHour_s, "tramMetro");
         double timeTaxi = timeAutoD;
 
-        int monthlyIncome_EUR = household.getMonthlyIncome_EUR();
+        int monthlyIncome_EUR = household.getMonthlyIncome();
 
         double gcAutoD;
         double gcAutoP;

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/modules/ModeChoiceCalculatorImpl.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/modules/ModeChoiceCalculatorImpl.java
@@ -504,7 +504,7 @@ public class ModeChoiceCalculatorImpl extends AbstractModeChoiceCalculator {
         double timeTrain = travelTimes.getTravelTime(originZone, destinationZone, peakHour_s, "train");
         double timeTramMetro = travelTimes.getTravelTime(originZone, destinationZone, peakHour_s, "tramMetro");
 
-        int monthlyIncome_EUR = household.getMonthlyIncome_EUR();
+        int monthlyIncome_EUR = household.getMonthlyIncome();
         int purpIdx;
         if (purpose.equals(Purpose.HBR)){
             purpIdx = Purpose.HBO.ordinal();

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/av/AVModeChoiceCalculatorImpl.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/av/AVModeChoiceCalculatorImpl.java
@@ -169,7 +169,7 @@ public class AVModeChoiceCalculatorImpl implements ModeChoiceCalculator {
     @Override
     public EnumMap<Mode, Double> calculateGeneralizedCosts(Purpose purpose, MitoHousehold household, MitoPerson person, MitoZone originZone, MitoZone destinationZone, TravelTimes travelTimes, double travelDistanceAuto, double travelDistanceNMT, double peakHour_s) {
 
-        int monthlyIncome_EUR = household.getMonthlyIncome_EUR();
+        int monthlyIncome_EUR = household.getMonthlyIncome();
         int purpIdx;
         if (purpose.equals(Purpose.HBR)){
             purpIdx = Purpose.HBO.ordinal();

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/drtNoise/DrtAutoNestModeChoiceCalculatorImpl.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/drtNoise/DrtAutoNestModeChoiceCalculatorImpl.java
@@ -163,7 +163,7 @@ public class DrtAutoNestModeChoiceCalculatorImpl implements ModeChoiceCalculator
 
     @Override
     public EnumMap<Mode, Double> calculateGeneralizedCosts(Purpose purpose, MitoHousehold household, MitoPerson person, MitoZone originZone, MitoZone destinationZone, TravelTimes travelTimes, double travelDistanceAuto, double travelDistanceNMT, double peakHour_s) {
-        int monthlyIncome_EUR = household.getMonthlyIncome_EUR();
+        int monthlyIncome_EUR = household.getMonthlyIncome();
         int purpIdx;
         if (purpose.equals(Purpose.HBR)){
             purpIdx = Purpose.HBO.ordinal();

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/drtNoise/DrtTopNestModeChoiceCalculatorImpl.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/drtNoise/DrtTopNestModeChoiceCalculatorImpl.java
@@ -169,7 +169,7 @@ public class DrtTopNestModeChoiceCalculatorImpl implements ModeChoiceCalculator 
 
     @Override
     public EnumMap<Mode, Double> calculateGeneralizedCosts(Purpose purpose, MitoHousehold household, MitoPerson person, MitoZone originZone, MitoZone destinationZone, TravelTimes travelTimes, double travelDistanceAuto, double travelDistanceNMT, double peakHour_s) {
-        int monthlyIncome_EUR = household.getMonthlyIncome_EUR();
+        int monthlyIncome_EUR = household.getMonthlyIncome();
         int purpIdx;
         if (purpose.equals(Purpose.HBR)){
             purpIdx = Purpose.HBO.ordinal();

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/mito7days/calculators/ModeChoiceCalculator2017NewImpl.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/mito7days/calculators/ModeChoiceCalculator2017NewImpl.java
@@ -113,7 +113,7 @@ public class ModeChoiceCalculator2017NewImpl extends AbstractModeChoiceCalculato
         double timeTrain = travelTimes.getTravelTime(originZone, destinationZone, peakHour_s, "train");
         double timeTramMetro = travelTimes.getTravelTime(originZone, destinationZone, peakHour_s, "tramMetro");
 
-        int monthlyIncome_EUR = household.getMonthlyIncome_EUR();
+        int monthlyIncome_EUR = household.getMonthlyIncome();
 
         double gcAutoD;
         double gcAutoP;

--- a/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/mito7days/calculators/ModeSetCalculator7days.java
+++ b/useCases/munich/src/main/java/de/tum/bgu/msm/scenarios/mito7days/calculators/ModeSetCalculator7days.java
@@ -1,7 +1,6 @@
 package de.tum.bgu.msm.scenarios.mito7days.calculators;
 
 import de.tum.bgu.msm.data.*;
-import de.tum.bgu.msm.data.travelTimes.TravelTimes;
 import de.tum.bgu.msm.modules.ModeSetCalculator;
 import de.tum.bgu.msm.util.LogitTools;
 
@@ -58,7 +57,7 @@ public class ModeSetCalculator7days implements ModeSetCalculator {
         predictor += coefficients.get("INTERCEPT");
 
         // Economic status (MOP version)
-        double econStatusMop = hh.getMonthlyIncome_EUR() / householdSizeAdj;
+        double econStatusMop = hh.getMonthlyIncome() / householdSizeAdj;
         if (econStatusMop > 800) {
             predictor += coefficients.get("hh.econStatus_2");
         } else if (econStatusMop > 1600) {


### PR DESCRIPTION
This update addresses hard-coded currency in functions related to evaluating household monthly income in MITO; these functions and related variables have the suffix '_EUR' for euros.  This applies in Germany and other parts of Europe, but not for Manchester, Melbourne, or other parts of the world.  For the sake of generalisation and to avoid confusion, I think we should correct this.