### PR TITLE
addresses #48, setting missing trip attraction coefficient for Melbou…

### DIFF
--- a/useCases/melbourne/src/main/java/uk/cam/mrc/phm/io/TripAttractionRatesReaderMEL.java
+++ b/useCases/melbourne/src/main/java/uk/cam/mrc/phm/io/TripAttractionRatesReaderMEL.java
@@ -53,8 +53,8 @@ public class TripAttractionRatesReaderMEL extends AbstractCsvReader {
     protected void processRecord(String[] record) {
         ExplanatoryVariable variable = ExplanatoryVariable.valueOf(record[variableIndex]);
         if (!indexForPurpose.containsKey(purpose)) {
-            purpose.setTripAttractionForVariable(variable, 0.0);
-            logger.warn("Purpose {} not found in header; setting trip attraction rate for variable {} to 0.0", purpose.name(), variable);
+            purpose.setTripAttractionForVariable(variable, 1.0);
+            logger.warn("Purpose {} not found in header; setting trip attraction rate for variable {} to 1.0 (constant)", purpose.name(), variable);
         } else {
             double rate = Double.parseDouble(record[indexForPurpose.get(purpose)]);
             purpose.setTripAttractionForVariable(variable, rate);


### PR DESCRIPTION
This pull request includes a single change to the `TripAttractionRatesReaderMEL.java` file. The change modifies the default trip attraction rate for a variable when a purpose is not found in the header, updating it from `0.0` to `1.0` and adding clarification in the log message.